### PR TITLE
Backport to 1.18.2

### DIFF
--- a/fabric/src/main/java/com/illusivesoulworks/spectrelib/mixin/SpectreLibMixinMinecraft.java
+++ b/fabric/src/main/java/com/illusivesoulworks/spectrelib/mixin/SpectreLibMixinMinecraft.java
@@ -28,7 +28,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 @Mixin(Minecraft.class)
 public class SpectreLibMixinMinecraft {
 
-  @Inject(at = @At(value = "INVOKE", target = "net/minecraft/network/chat/contents/KeybindResolver.setKeyResolver(Ljava/util/function/Function;)V"), method = "<init>")
+  @Inject(at = @At(value = "INVOKE", target = "net/minecraft/network/chat/KeybindComponent.setKeyResolver(Ljava/util/function/Function;)V"), method = "<init>")
   private void spectrelib$init(GameConfig config, CallbackInfo ci) {
     SpectreClientFabricMod.prepareConfigs(config);
   }

--- a/forge/src/main/java/com/illusivesoulworks/spectrelib/SpectreClientForgeMod.java
+++ b/forge/src/main/java/com/illusivesoulworks/spectrelib/SpectreClientForgeMod.java
@@ -28,7 +28,7 @@ public class SpectreClientForgeMod {
     MinecraftForge.EVENT_BUS.addListener(SpectreClientForgeMod::onPlayerLoggedOut);
   }
 
-  private static void onPlayerLoggedOut(final ClientPlayerNetworkEvent.LoggingOut evt) {
+  private static void onPlayerLoggedOut(final ClientPlayerNetworkEvent.LoggedOutEvent evt) {
 
     if (!Minecraft.getInstance().isLocalServer()) {
       SpectreConfigEvents.onUnloadServer();

--- a/forge/src/main/java/com/illusivesoulworks/spectrelib/SpectreForgeMod.java
+++ b/forge/src/main/java/com/illusivesoulworks/spectrelib/SpectreForgeMod.java
@@ -25,7 +25,6 @@ import io.netty.buffer.Unpooled;
 import java.util.List;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.server.level.ServerPlayer;
-import net.minecraft.world.entity.player.Player;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.entity.player.PlayerEvent;
 import net.minecraftforge.event.server.ServerAboutToStartEvent;
@@ -72,9 +71,7 @@ public class SpectreForgeMod {
   }
 
   private void onPlayerLoggedIn(final PlayerEvent.PlayerLoggedInEvent evt) {
-    Player player = evt.getEntity();
-
-    if (player instanceof ServerPlayer serverPlayer) {
+    if (evt.getEntity() instanceof ServerPlayer serverPlayer) {
       List<FriendlyByteBuf> configData = SpectreConfigNetwork.getConfigSync();
 
       if (!configData.isEmpty()) {

--- a/forge/src/main/resources/META-INF/mods.toml
+++ b/forge/src/main/resources/META-INF/mods.toml
@@ -1,5 +1,5 @@
 modLoader="javafml"
-loaderVersion="[41,)"
+loaderVersion="[40,)"
 license="${license}"
 [[mods]]
 modId="${mod_id}"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,33 +1,33 @@
 # Project
-version=0.12.5+1.19.2
+version=0.10.0+1.18.2
 group=com.illusivesoulworks.spectrelib
 license=LGPL-2.1-only
 
 # Common
-minecraft_version=1.19.2
+minecraft_version=1.18.2
 common_runs_enabled=false
 common_client_run_name=Common Client
 common_server_run_name=Common Server
 
 # Parchment
-parchment_mc_version=1.19.2
-parchment_version=2022.11.27
+parchment_mc_version=1.18.2
+parchment_version=2022.09.04
 
 # Forge
-forge_version=43.2.0
-forge_version_range=[41.0.94,)
-forge_mc_version_range=[1.19,1.20)
+forge_version=40.2.10
+forge_version_range=[40,)
+forge_mc_version_range=[1.18.2,1.19)
 //forge_ats_enabled=true
 
 # Fabric
-fabric_version=0.69.0+1.19.2
-fabric_mc_version_range=1.19.x
-fabric_loader_version=0.14.11
+fabric_version=0.76.0+1.18.2
+fabric_mc_version_range=1.18.2
+fabric_loader_version=0.14.22
 
 # Quilt
-quilt_stdlib_version=3.0.0-beta.24+1.19.2
-quilt_mc_version_range=1.19.x
-quilt_loader_version=0.18.1-beta.23
+quilt_stdlib_version=1.1.0-beta.26+1.18.2
+quilt_mc_version_range=1.18.2
+quilt_loader_version=0.17.5-beta.1
 
 # Mod options
 mod_name=SpectreLib


### PR DESCRIPTION
I can't really make a true backport PR on github, as it would need a new branch. This is just to share the changes I made to build against 1.18.2. I have a few mods I develop with my kids and one of them wanted their mod backported to 1.18.2 (to be able to play TCon) so I just ported locally and did the jarJar thing. I just wanted to share, as it is pretty trivial set of changes for 1.18.2. It would be awesome if it was in your maven :)

No expectations. Do what you want with this. I truly appreciate all of the amazing mods and code!